### PR TITLE
Writing all events to console. Updating to Tomcat version 9.0.38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ ARG SERVER_XML=server.xml
 ARG LOGGING_PROPERTIES=logging.properties
 ARG CATALINA_PROPERTIES=catalina.properties
 ARG TOMCAT_MAJOR=9
+
+# As provided here, only the access log gets written to this location.
+# Mount to a persistant volume to preserve access logs.
+# Modify this value to specify a different log directory.
+# e.g. /home/logs in Azure App Service
 ENV LOG_ROOT=/tomcat_logs
 
 ENV PATH /usr/local/tomcat/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG CATALINA_PROPERTIES=catalina.properties
 ARG TOMCAT_MAJOR=9
 
 # As provided here, only the access log gets written to this location.
-# Mount to a persistant volume to preserve access logs.
+# Mount to a persistent volume to preserve access logs.
 # Modify this value to specify a different log directory.
 # e.g. /home/logs in Azure App Service
 ENV LOG_ROOT=/tomcat_logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/java/jdk:8-zulu-alpine
 ARG APP_FILE=ROOT.war
-ARG TOMCAT_VERSION=9.0.31
+ARG TOMCAT_VERSION=9.0.38
 ARG SERVER_XML=server.xml
 ARG LOGGING_PROPERTIES=logging.properties
 ARG CATALINA_PROPERTIES=catalina.properties

--- a/logging.properties
+++ b/logging.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-# This file has been modified from Tomcat's original to redirect all loging to the console.
+# This file has been modified from Tomcat's original to redirect all logging to the console.
 # Console output of containers can be consumed by Azure Monitor and other services.
 
 # For more information about enabling Azure Monitor for Containers, see

--- a/logging.properties
+++ b/logging.properties
@@ -13,38 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
 
-.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+# This file has been modified from Tomcat's original to redirect all loging to the console.
+# Console output of containers can be consumed by Azure Monitor and other services.
+
+# For more information about enabling Azure Monitor for Containers, see
+# https://docs.microsoft.com/azure/azure-monitor/insights/container-insights-enable-existing-clusters
+
+# For more information about querying logs with Azure Monitor for containers, see
+# https://docs.microsoft.com/azure/azure-monitor/insights/container-insights-log-search#search-logs-to-analyze-data
+
+
+handlers = 1catalina.java.util.logging.ConsoleHandler, 2localhost.java.util.logging.ConsoleHandler, 3manager.java.util.logging.ConsoleHandler, 4host-manager.java.util.logging.ConsoleHandler, java.util.logging.ConsoleHandler
+
+.handlers = java.util.logging.ConsoleHandler
 
 ############################################################
 # Handler specific properties.
 # Describes specific configuration info for Handlers.
 ############################################################
-
-1catalina.org.apache.juli.AsyncFileHandler.level = FINE
-1catalina.org.apache.juli.AsyncFileHandler.directory = ${log.base}/Application
-1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
-1catalina.org.apache.juli.AsyncFileHandler.maxDays = 90
-1catalina.org.apache.juli.AsyncFileHandler.encoding = UTF-8
-
-2localhost.org.apache.juli.AsyncFileHandler.level = FINE
-2localhost.org.apache.juli.AsyncFileHandler.directory = ${log.base}/Application
-2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
-2localhost.org.apache.juli.AsyncFileHandler.maxDays = 90
-2localhost.org.apache.juli.AsyncFileHandler.encoding = UTF-8
-
-3manager.org.apache.juli.AsyncFileHandler.level = FINE
-3manager.org.apache.juli.AsyncFileHandler.directory = ${log.base}/Application
-3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
-3manager.org.apache.juli.AsyncFileHandler.maxDays = 90
-3manager.org.apache.juli.AsyncFileHandler.encoding = UTF-8
-
-4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
-4host-manager.org.apache.juli.AsyncFileHandler.directory = ${log.base}/Application
-4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
-4host-manager.org.apache.juli.AsyncFileHandler.maxDays = 90
-4host-manager.org.apache.juli.AsyncFileHandler.encoding = UTF-8
 
 java.util.logging.ConsoleHandler.level = FINE
 java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
@@ -57,13 +44,13 @@ java.util.logging.ConsoleHandler.encoding = UTF-8
 ############################################################
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = java.util.logging.ConsoleHandler
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = java.util.logging.ConsoleHandler
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = java.util.logging.ConsoleHandler
 
 # For example, set the org.apache.catalina.util.LifecycleBase logger to log
 # each component that extends LifecycleBase changing state:

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# Create a log directory for each hostname in case a shared file system is used among multiple hosts or containers.
+# As provided in the default configuration, only the access log gets written to this directory.
 LOG_DIR="${LOG_ROOT}/$(hostname)"
 mkdir -p "${LOG_DIR}"
 export JAVA_OPTS="${JAVA_OPTS} -Dlog.base=${LOG_DIR}"


### PR DESCRIPTION
* Redirecting all log output (except access log which is always written locally) to standard out.
* Updating tomcat version to 9.0.38